### PR TITLE
可变参数的灵活运用

### DIFF
--- a/RuntimeInvoker.xcodeproj/project.pbxproj
+++ b/RuntimeInvoker.xcodeproj/project.pbxproj
@@ -112,7 +112,7 @@
 				TargetAttributes = {
 					87E828731CF81B5E008E25AF = {
 						CreatedOnToolsVersion = 7.2.1;
-						DevelopmentTeam = 69R9Y4CDGR;
+						DevelopmentTeam = NKW67GFDHM;
 					};
 				};
 			};
@@ -262,7 +262,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 69R9Y4CDGR;
+				DEVELOPMENT_TEAM = NKW67GFDHM;
 				INFOPLIST_FILE = RuntimeInvoker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = lib.cyan.RuntimeInvoker;
@@ -274,7 +274,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 69R9Y4CDGR;
+				DEVELOPMENT_TEAM = NKW67GFDHM;
 				INFOPLIST_FILE = RuntimeInvoker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = lib.cyan.RuntimeInvoker;

--- a/RuntimeInvoker.xcodeproj/project.pbxproj
+++ b/RuntimeInvoker.xcodeproj/project.pbxproj
@@ -112,7 +112,7 @@
 				TargetAttributes = {
 					87E828731CF81B5E008E25AF = {
 						CreatedOnToolsVersion = 7.2.1;
-						DevelopmentTeam = TCKG8FBVG6;
+						DevelopmentTeam = 69R9Y4CDGR;
 					};
 				};
 			};
@@ -262,7 +262,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = TCKG8FBVG6;
+				DEVELOPMENT_TEAM = 69R9Y4CDGR;
 				INFOPLIST_FILE = RuntimeInvoker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = lib.cyan.RuntimeInvoker;
@@ -274,7 +274,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = TCKG8FBVG6;
+				DEVELOPMENT_TEAM = 69R9Y4CDGR;
 				INFOPLIST_FILE = RuntimeInvoker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = lib.cyan.RuntimeInvoker;

--- a/RuntimeInvoker/RuntimeInvoker.m
+++ b/RuntimeInvoker/RuntimeInvoker.m
@@ -10,14 +10,18 @@
 #import <UIKit/UIKit.h>
 
 #define _DEFINE_ARRAY(arg) \
-NSMutableArray *array = [NSMutableArray arrayWithObject:arg];\
-va_list args;\
-va_start(args, arg);\
-id next = nil;\
-while ((next = va_arg(args,id))) {\
-    [array addObject:next];\
-}\
-va_end(args);\
+    NSMutableArray *array = nil;\
+    if (arg) {\
+        array = [NSMutableArray arrayWithObject:arg];\
+        va_list args;\
+        va_start(args, arg);\
+        id next = nil;\
+        while ((next = va_arg(args,id))) {\
+            [array addObject:next];\
+        }\
+        va_end(args);\
+    }\
+
 
 #pragma mark - NSMethodSignature Category
 

--- a/RuntimeInvoker/RuntimeInvoker.m
+++ b/RuntimeInvoker/RuntimeInvoker.m
@@ -386,6 +386,13 @@ id _invoke(id target, NSString *selector, NSArray *arguments) {
     SEL sel = NSSelectorFromString(selector);
     NSMethodSignature *signature = [target methodSignatureForSelector:sel];
     if (signature) {
+        // Get the number of parameters required in selector
+        NSInteger argumentsCount = [selector length] - [[selector stringByReplacingOccurrencesOfString:@":" withString:@""] length];
+        if (arguments.count > argumentsCount) {
+            // Remove the redundant parameters from arguments. When I execute the classification invoke:arguments:, no matter how many parameters, I only keep the valid parameter part with selector.
+            arguments = [arguments objectsAtIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, arguments.count-(arguments.count-argumentsCount))]];
+        }
+        
         NSInvocation *invocation = [signature invocationWithArguments:arguments];
         id returnValue = [invocation invoke:target selector:sel returnType:signature.returnType];
         return returnValue;

--- a/RuntimeInvoker/ViewController.m
+++ b/RuntimeInvoker/ViewController.m
@@ -9,7 +9,17 @@
 #import "ViewController.h"
 #import "RuntimeInvoker.h"
 
-@implementation ViewController
+@interface ExampleItem : NSObject
+
+@property (nonatomic, assign, readonly) SEL actionSelector;
+@property (nonatomic, weak, readonly) id actionTarget;
+- (instancetype)initWithTarget:(id)target action:(SEL)actionSelector;
+
+@end
+
+@implementation ViewController {
+    NSMutableArray<ExampleItem *> *_items;
+}
 
 - (CGRect)aRect {
     return CGRectMake(0, 0, 100, 100);
@@ -52,6 +62,74 @@
     UIColor *color = [UIColor invoke:@"colorWithRed:green:blue:alpha:"
                                 args:@(0), @(0.5), @(1), nil];
     NSLog(@"color: %@", color);
+    
+    [self exampleVariableParameter];
+}
+
+- (void)exampleVariableParameter {
+    _items = @[].mutableCopy;//[self.view valueForKey:@"_UIRemoteView"]
+    ExampleItem *item0 = [[ExampleItem alloc] initWithTarget:self action:@selector(actionTest)];
+    ExampleItem *item1 = [[ExampleItem alloc] initWithTarget:self action:@selector(actionTestWithArg1:)];
+    ExampleItem *item2 = [[ExampleItem alloc] initWithTarget:self action:@selector(actionTestWithArg1:arg2:)];
+    ExampleItem *item3 = [[ExampleItem alloc] initWithTarget:self action:@selector(actionTestWithArg1:arg2:arg3:)];
+     ExampleItem *item4 = [[ExampleItem alloc] initWithTarget:self action:@selector(actionTestWithArg1:arg2:arg3:arg4:)];
+    ExampleItem *item5 = [[ExampleItem alloc] initWithTarget:self action:@selector(actionTestWithArg1:arg2:arg3:arg4:arg5:)];
+    [_items addObject:item0];
+    [_items addObject:item1];
+    [_items addObject:item2];
+    [_items addObject:item3];
+    [_items addObject:item4];
+    [_items addObject:item5];
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [_items enumerateObjectsUsingBlock:^(ExampleItem * _Nonnull item, NSUInteger idx, BOOL * _Nonnull stop) {
+            [item.actionTarget invoke:NSStringFromSelector(item.actionSelector) args:@"model", self, nil, @"hello", nil];
+        }];
+    });
+}
+
+- (void)actionTest {
+    
+}
+
+- (void)actionTestWithArg1:(id)arg1 {
+    
+}
+
+- (void)actionTestWithArg1:(id)arg1 arg2:(id)arg2 {
+    
+}
+
+- (void)actionTestWithArg1:(id)arg1 arg2:(id)arg2 arg3:(id)arg3 {
+    
+}
+
+- (void)actionTestWithArg1:(id)arg1 arg2:(id)arg2 arg3:(id)arg3 arg4:(id)arg4 {
+    
+}
+
+- (void)actionTestWithArg1:(id)arg1 arg2:(id)arg2 arg3:(id)arg3 arg4:(id)arg4 arg5:(id)arg5 {
+    
+}
+
+
+
+@end
+
+@implementation ExampleItem
+{
+    SEL _actionSelector;
+    __weak id _actionTarget;
+}
+
+@synthesize actionSelector = _actionSelector, actionTarget = _actionTarget;
+
+- (instancetype)initWithTarget:(id)target action:(SEL)actionSelector {
+    if (self = [super init]) {
+        _actionTarget = target;
+        _actionSelector = actionSelector;
+    }
+    return self;
 }
 
 @end

--- a/RuntimeInvoker/ViewController.m
+++ b/RuntimeInvoker/ViewController.m
@@ -67,7 +67,7 @@
 }
 
 - (void)exampleVariableParameter {
-    _items = @[].mutableCopy;//[self.view valueForKey:@"_UIRemoteView"]
+    _items = @[].mutableCopy;
     ExampleItem *item0 = [[ExampleItem alloc] initWithTarget:self action:@selector(actionTest)];
     ExampleItem *item1 = [[ExampleItem alloc] initWithTarget:self action:@selector(actionTestWithArg1:)];
     ExampleItem *item2 = [[ExampleItem alloc] initWithTarget:self action:@selector(actionTestWithArg1:arg2:)];

--- a/RuntimeInvoker/ViewController.m
+++ b/RuntimeInvoker/ViewController.m
@@ -63,54 +63,44 @@
                                 args:@(0), @(0.5), @(1), nil];
     NSLog(@"color: %@", color);
     
-    [self exampleVariableParameter];
+    [self variableParameterExample];
 }
 
-- (void)exampleVariableParameter {
+/// Flexible use of variable parameters.
+- (void)variableParameterExample {
     _items = @[].mutableCopy;
     ExampleItem *item0 = [[ExampleItem alloc] initWithTarget:self action:@selector(actionTest)];
     ExampleItem *item1 = [[ExampleItem alloc] initWithTarget:self action:@selector(actionTestWithArg1:)];
     ExampleItem *item2 = [[ExampleItem alloc] initWithTarget:self action:@selector(actionTestWithArg1:arg2:)];
     ExampleItem *item3 = [[ExampleItem alloc] initWithTarget:self action:@selector(actionTestWithArg1:arg2:arg3:)];
-     ExampleItem *item4 = [[ExampleItem alloc] initWithTarget:self action:@selector(actionTestWithArg1:arg2:arg3:arg4:)];
-    ExampleItem *item5 = [[ExampleItem alloc] initWithTarget:self action:@selector(actionTestWithArg1:arg2:arg3:arg4:arg5:)];
     [_items addObject:item0];
     [_items addObject:item1];
     [_items addObject:item2];
     [_items addObject:item3];
-    [_items addObject:item4];
-    [_items addObject:item5];
     
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         [_items enumerateObjectsUsingBlock:^(ExampleItem * _Nonnull item, NSUInteger idx, BOOL * _Nonnull stop) {
-            [item.actionTarget invoke:NSStringFromSelector(item.actionSelector) args:@"model", self, nil, @"hello", nil];
+            [item.actionTarget invoke:NSStringFromSelector(item.actionSelector) args:@"index", item, self, @"superfluous parameters", nil];
         }];
     });
 }
 
 - (void)actionTest {
-    
+    NSLog(@"%s", __FUNCTION__);
 }
 
 - (void)actionTestWithArg1:(id)arg1 {
-    
+    NSLog(@"%@__%s", arg1, __FUNCTION__);
 }
 
 - (void)actionTestWithArg1:(id)arg1 arg2:(id)arg2 {
-    
+    NSLog(@"%@__%@__%s", arg1, arg2, __FUNCTION__);
 }
 
 - (void)actionTestWithArg1:(id)arg1 arg2:(id)arg2 arg3:(id)arg3 {
-    
+    NSLog(@"%@__%@__%@__%s", arg1, arg2, arg3, __FUNCTION__);
 }
 
-- (void)actionTestWithArg1:(id)arg1 arg2:(id)arg2 arg3:(id)arg3 arg4:(id)arg4 {
-    
-}
-
-- (void)actionTestWithArg1:(id)arg1 arg2:(id)arg2 arg3:(id)arg3 arg4:(id)arg4 arg5:(id)arg5 {
-    
-}
 
 
 


### PR DESCRIPTION
你好:
   我在项目中使用了RuntimeInvoker，RuntimeInvoker可变参数的方法使用非常方便，我对它进行了改进，我觉得改进的部分可能也适用于其他开发者，所以我执行了pull request，希望得到作者的同意!

####  修改如下
- 1. 更灵活的使用NSInvocation的参数
> 执行-invoke::方法时，可变参数中有两个固定参数，但是Selector可能只接受一个参数或不需要参数，作者可以看下pull request的ViewController的-variableParameterExample示例方法。
下面是主要修改的代码:
```
id _invoke(id target, NSString *selector, NSArray *arguments) {
    SEL sel = NSSelectorFromString(selector);
    NSMethodSignature *signature = [target methodSignatureForSelector:sel];
    if (signature) {
        // Get the number of parameters required in selector
        NSInteger argumentsCount = [selector length] - [[selector stringByReplacingOccurrencesOfString:@":" withString:@""] length];
        if (arguments.count > argumentsCount) {
            // Remove the redundant parameters from arguments. When I execute the classification invoke:arguments:, no matter how many parameters, I only keep the valid parameter part with selector.
            arguments = [arguments objectsAtIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, arguments.count-(arguments.count-argumentsCount))]];
        }
        
        NSInvocation *invocation = [signature invocationWithArguments:arguments];
        id returnValue = [invocation invoke:target selector:sel returnType:signature.returnType];
        return returnValue;
    } else {
        NSLog(@"# RuntimeInvoker # selector: \"%@\" NOT FOUND", selector);
        return nil;
    }
}
```
- 2.Fix bug: 当执行-invoke:: 参数为可变类型时，第一个参数为nil，导致crash。

 
  